### PR TITLE
Check if chapter xhtml is integer

### DIFF
--- a/src/pages/Epub.vue
+++ b/src/pages/Epub.vue
@@ -115,7 +115,7 @@ export default {
       }
     },
     goToExcerpt () {
-      if (this.chapter.toLowerCase().indexOf('xhtml') > 0) {
+      if (Number.isInteger(this.chapter.toLowerCase().indexOf('xhtml'))) {
         this.rendition.display(this.chapter)
       } else {
         this.rendition.display('epubcfi(' + this.chapter + ')')


### PR DESCRIPTION
I think the distinction for this line is whether the response is an integer, rather than whether it is above 0? 

I came across an ePub that had -1 as the returned string and caused and error as it was supposed to be processed as this.chapter but was passed on to epubcfi (https://contentserver.adobe.com/store/books/GeographyofBliss_oneChapter.epub). 